### PR TITLE
Feature/rewrite ext dataset path

### DIFF
--- a/notebooks/R9-external_corr_venn_plot-YR.ipynb
+++ b/notebooks/R9-external_corr_venn_plot-YR.ipynb
@@ -28,7 +28,7 @@
     "### Load and read PC9 and To data\n",
     "pc9_dir = '../out/21.0423 Lx PC9/L200only_reg_rf_boruta/anlyz'\n",
     "to_dir = '../out/21.0506 Lx To/L200only_reg_rf_boruta/anlyz'\n",
-    "to_org_dir = '../data/DepMap/To'\n",
+    "to_org_dir = '../data/ceres_external/To'\n",
     "\n",
     "df_pc9 = pickle.load(open(join(pc9_dir,'y_compr_ext.pkl'),'rb'))\n",
     "df_to = pickle.load(open(join(to_dir,'y_compr_ext.pkl'),'rb'))\n",
@@ -365,7 +365,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,

--- a/notebooks/Rrun01a-preprocess_PC9-YR.ipynb
+++ b/notebooks/Rrun01a-preprocess_PC9-YR.ipynb
@@ -16,8 +16,8 @@
    "outputs": [],
    "source": [
     "# Preprocess data for gene effect (continuous)\n",
-    "ext_data = {'dir_datasets': '19Q3',\n",
-    "\t\t\t'dir_ceres_datasets': 'PC9_corrected',\n",
+    "ext_data = {'dir_datasets': '../datasets/DepMap_DROP_PC9/19Q3',\n",
+    "\t\t\t'dir_ceres_datasets': '../datasets/ceres_external/PC9_corrected',\n",
     "\t\t\t'data_name': 'data_pc9',\n",
     "\t\t\t'fname_gene_effect': 'gene_effect.csv',\n",
     "\t\t\t'fname_gene_dependency': None,\n",
@@ -47,7 +47,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,

--- a/notebooks/Rrun02a-preprocess_To_YR.ipynb
+++ b/notebooks/Rrun02a-preprocess_To_YR.ipynb
@@ -136,8 +136,8 @@
    ],
    "source": [
     "# Preprocess data for gene effect (continuous)\n",
-    "ext_data = {'dir_datasets': '19Q3',\n",
-    "\t\t\t'dir_ceres_datasets': 'To',\n",
+    "ext_data = {'dir_datasets': '../datasets/DepMap/19Q3',\n",
+    "\t\t\t'dir_ceres_datasets': '../datasets/ceres_external/To',\n",
     "\t\t\t'data_name': 'data_to',\n",
     "\t\t\t'fname_gene_effect': 'gene_effect.csv',\n",
     "\t\t\t'fname_gene_dependency': None,\n",
@@ -167,7 +167,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,

--- a/notebooks/run01-preprocess_data-Sanger.ipynb
+++ b/notebooks/run01-preprocess_data-Sanger.ipynb
@@ -147,8 +147,8 @@
    ],
    "source": [
     "# Preprocess data for gene effect (continuous)\n",
-    "ext_data = {'dir_datesets': '19Q3',\n",
-    "\t\t\t'dir_ceres_datasets': '19Q3/Sanger',\n",
+    "ext_data = {'dir_datasets': '../datasets/DepMap/19Q3',\n",
+    "\t\t\t'dir_ceres_datasets': '../datasets/DepMap/Sanger',\n",
     "\t\t\t'data_name': 'data_sanger',\n",
     "\t\t\t'fname_gene_effect': 'gene_effect.csv',\n",
     "\t\t\t'fname_gene_dependency': 'gene_dependency.csv',\n",

--- a/src/ceres_infer/data.py
+++ b/src/ceres_infer/data.py
@@ -489,8 +489,8 @@ def preprocessData(useGene_dependency, dir_out, dir_depmap = '../datasets/DepMap
     # ------------------
     if ext_data is not None:
         dm_data_ext= depmap_data()
-        dm_data_ext.dir_datasets = os.path.join(dir_depmap, ext_data['dir_datasets'])
-        dm_data_ext.dir_ceres_datasets = os.path.join(dir_depmap, ext_data['dir_ceres_datasets'])
+        dm_data_ext.dir_datasets = ext_data['dir_datasets']
+        dm_data_ext.dir_ceres_datasets = ext_data['dir_ceres_datasets']
         dm_data_ext.data_name = ext_data['data_name']
         dm_data_ext.fname_gene_effect = ext_data['fname_gene_effect']
         dm_data_ext.fname_gene_dependency = ext_data['fname_gene_dependency']


### PR DESCRIPTION
This is a minor modification to the preprocessing, so external dataset paths can be flexible defined (previously the path have to be within the DepMap directory). Paths in corresponding notebooks related to To, Sanger, and PC9 have also been updated. 